### PR TITLE
add go_install description for package with major version suffix

### DIFF
--- a/docs/reference/registry-config/go-install-package.md
+++ b/docs/reference/registry-config/go-install-package.md
@@ -15,7 +15,7 @@ When aqua runs `go install`, aqua sets the environment variable `GOBIN`.
 
 aqua is a CLI Version Manager, you have to specify the version. You can't specify `latest`.
 
-e.g. [golang.org/x/perf/cmd/benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
+e.g. [golang.org/x/perf/cmd/benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat), [github.com/volatiletech/sqlboiler/v4](https://github.com/volatiletech/sqlboiler)
 
 registry.yaml
 
@@ -24,6 +24,11 @@ packages:
   - type: go_install
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks
+  - type: go_install
+    path: github.com/volatiletech/sqlboiler/v4
+    # specify `asset` when use package ends with major version
+    asset: sqlboiler
+    description: Generate a Go ORM tailored to your database schema.
 ```
 
 aqua.yaml
@@ -37,14 +42,22 @@ packages:
   - name: golang.org/x/perf/cmd/benchstat
     registry: local
     version: 84e58bfe0a7e5416369e236afa007d5d9c58a0fa
+  - name: github.com/volatiletech/sqlboiler/v4
+    registry: local
+    version: v4.12.0
 ```
 
 ```console
 $ aqua i
-INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/benchstat new=aqua-proxy package_name=golang.org/x/perf/cmd/benchstat package_version=84e58bfe0a7e5416369e236afa007d5d9c58a0fa program=aqua registry=local
-INFO[0000] Installing a Go tool                          aqua_version= env=darwin/arm64 go_package_path=golang.org/x/perf/cmd/benchstat@84e58bfe0a7e5416369e236afa007d5d9c58a0fa gobin=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go_install/golang.org/x/perf/cmd/benchstat/84e58bfe0a7e5416369e236afa007d5d9c58a0fa/bin package_name=golang.org/x/perf/cmd/benchstat package_version=84e58bfe0a7e5416369e236afa007d5d9c58a0fa program=aqua registry=local
-go: downloading golang.org/x/perf v0.0.0-20220411212318-84e58bfe0a7e
+INFO[0000] download and unarchive the package            aqua_version=1.18.0 env=darwin/amd64 package_name=aqua-proxy package_version=v1.1.2 program=aqua registry=
+INFO[0000] create a symbolic link                        aqua_version=1.18.0 env=darwin/amd64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/aqua-proxy new=../pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.2/aqua-proxy_darwin_amd64.tar.gz/aqua-proxy package_name=aqua-proxy package_version=v1.1.2 program=aqua registry=
+INFO[0000] create a symbolic link                        aqua_version=1.18.0 env=darwin/amd64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/benchstat new=aqua-proxy program=aqua
+INFO[0000] create a symbolic link                        aqua_version=1.18.0 env=darwin/amd64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/sqlboiler new=aqua-proxy program=aqua
+INFO[0000] Installing a Go tool                          aqua_version=1.18.0 env=darwin/amd64 go_package_path=github.com/volatiletech/sqlboiler/v4@v4.12.0 gobin=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go_install/github.com/volatiletech/sqlboiler/v4/v4.12.0/bin package_name=github.com/volatiletech/sqlboiler/v4 package_version=v4.12.0 program=aqua registry=local
+INFO[0000] Installing a Go tool                          aqua_version=1.18.0 env=darwin/amd64 go_package_path=golang.org/x/perf/cmd/benchstat@84e58bfe0a7e5416369e236afa007d5d9c58a0fa gobin=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go_install/golang.org/x/perf/cmd/benchstat/84e58bfe0a7e5416369e236afa007d5d9c58a0fa/bin package_name=golang.org/x/perf/cmd/benchstat package_version=84e58bfe0a7e5416369e236afa007d5d9c58a0fa program=aqua registry=local
 
 $ aqua which benchstat
 /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go_install/golang.org/x/perf/cmd/benchstat/84e58bfe0a7e5416369e236afa007d5d9c58a0fa/bin/github-compare
+% aqua which sqlboiler
+/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go_install/github.com/volatiletech/sqlboiler/v4/v4.12.0/bin/sqlboiler
 ```


### PR DESCRIPTION
## What
- Add description of `go_install` package ends with major version

## Why
-  If `asset` is not specified, `exe_path isn't found:` error is caused, this is a little confused
  - https://github.com/hiro-o918/aqua/blob/07b725bf27d9029b53456215181d34a8b483f569/pkg/installpackage/installer.go#L226
