### PR TITLE
Change a link to split-config on Configuration page to absolute path

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -170,7 +170,7 @@ packages:
 * `registry`: (string, optional) registry name
   * default value is `standard`
 * `version`: (string, optional) package version
-* `import`: (string, optional) glob pattern of package files. This is relative path from the configuration file. This is parsed with [filepath.Glob](https://pkg.go.dev/path/filepath#Glob). Please see [Split the list of packages](../tutorial-extras/split-config) too
+* `import`: (string, optional) glob pattern of package files. This is relative path from the configuration file. This is parsed with [filepath.Glob](https://pkg.go.dev/path/filepath#Glob). Please see [Split the list of packages](/docs/tutorial-extras/split-config) too
 
 The following two configuration is equivalent.
 


### PR DESCRIPTION
The link to split-config on the Configuration page seems to be incorrect.
In this PR, change it to absolute path so that it can be referenced.

FYI: https://aquaproj.github.io/docs/reference/config/#packages
![image](https://user-images.githubusercontent.com/2923219/190068679-40697e18-3e97-4653-962f-806452e94b9a.png)
