### PR TITLE
Fix "aqua: not found" in container example

### DIFF
--- a/docs/tutorial-basics/quick-start.md
+++ b/docs/tutorial-basics/quick-start.md
@@ -46,11 +46,11 @@ If you want to try this tutorial in the clean environment, container is useful.
 ```console
 $ docker run --rm -ti alpine:3.15.0 sh
 # apk add curl
+# adduser -D foo
+# su foo
 # curl -sSfL \
   https://raw.githubusercontent.com/aquaproj/aqua-installer/v1.0.0/aqua-installer |
   sh
-# adduser -D foo
-# su foo
 $ mkdir ~/workspace
 $ cd ~/workspace
 $ export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"


### PR DESCRIPTION
Since the installer is run as `root`, `aqua` gets installed to `root`'s `$HOME`:
```
===> Install aqua latest (linux/amd64) to /root/.local/share/aquaproj-aqua/bin/aqua
```
However, since we add `aqua` to `PATH` after we've switched to the `foo` user, we add `foo`'s `$HOME` to the `PATH`, resulting in `aqua` not being found:
```
~/workspace $ echo $PATH
/home/foo/.local/share/aquaproj-aqua/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```
This can either be fixed by moving the installation to after we switch to `foo`, or moving the `PATH` modification to the `root` user. Since `aqua` doesn't require `root`, I've opted to emphasise this by moving the installation to the non-root user.