### PR TITLE
Add WinGet installation to Quick Start

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -21,6 +21,12 @@ Homebrew
 brew install aquaproj/aqua/aqua
 ```
 
+[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/) (Windows)
+
+```bash
+winget install aquaproj.aqua
+```
+
 [Scoop](https://scoop.sh/) (Windows)
 
 ```bash


### PR DESCRIPTION
While Windows support was mentioned, the Quick Start section only had installation instructions using Scoop.