### PR TITLE
Change path notation in Windows Support to a familiar cmd users

### DIFF
--- a/docs/reference/windows-support.md
+++ b/docs/reference/windows-support.md
@@ -56,12 +56,12 @@ scoop install aqua
 
 ## The install path (AQUA_ROOT_DIR)
 
-From aqua v1.12.0, the default value of `AQUA_ROOT_DIR` is `$HOME/AppData/Local/aquaproj-aqua`.
+From aqua v1.12.0, the default value of `AQUA_ROOT_DIR` is `%LOCALAPPDATA%\aquaproj-aqua`.
 
 ## PATH
 
-* Command Prompt,PowerShell: `AQUA_ROOT_DIR/bat`
-* Git Bash: `AQUA_ROOT_DIR/bin`
+* Command Prompt,PowerShell: `%AQUA_ROOT_DIR%\bat`
+* Git Bash: `%AQUA_ROOT_DIR%\bin`
 
 ## The separator of AQUA_GLOBAL_CONFIG
 
@@ -107,10 +107,10 @@ Please see [complete_windows_ext](/docs/reference/registry-config/complete-windo
 
 Reference (Japanese): https://zenn.dev/link/comments/725555a2b1b034
 
-aqua creates executable BAT files and shell scripts in directories `AQUA_ROOT_DIR/bin` and `AQUA_ROOT_DIR/bat` instead of symbolic links.
+aqua creates executable BAT files and shell scripts in directories `%AQUA_ROOT_DIR%\bin` and `%AQUA_ROOT_DIR%\bat` instead of symbolic links.
 
-If you use PowerShell or Command Prompt, please add `AQUA_ROOT_DIR/bat` to the environment variable `PATH`.
-Or if you use Git Bash, please add `AQUA_ROOT_DIR/bin` to the environment variable `PATH`.
+If you use PowerShell or Command Prompt, please add `%AQUA_ROOT_DIR%\bat` to the environment variable `PATH`.
+Or if you use Git Bash, please add `%AQUA_ROOT_DIR%\bin` to the environment variable `PATH`.
 
 #### Why is this change needed?
 


### PR DESCRIPTION
I'm updating the path notation in Windows Support to formats that are effective and familiar for Command Prompt and GUI users. However, as I seldom use PowerShell or GitBash, I am uncertain if these changes will be beneficial for users of those environments.
