### PR TITLE
docs: use invite link for discord

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ If you have any question, please contact us.
   - English: [@aquaclivm](https://twitter.com/aquaclivm), [@szkdash_en](https://twitter.com/szkdash_en)
   - Japanese: [@szkdash](https://twitter.com/szkdash)
 - Slack: [English](https://gophers.slack.com/archives/C04RALTG29K), [Japanese](https://gophers.slack.com/archives/C04RDHZQ9K5)
-- [Discord](https://discord.com/channels/1141777454164365382/1162444533959757955)
+- [Discord](https://discord.gg/CBGesz8yBX)
 
 ## For Japanese
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,6 +131,10 @@ const config = {
                 label: 'Twitter',
                 href: 'https://twitter.com/aquaclivm',
               },
+              {
+                label: 'Discord',
+                href: 'https://discord.gg/CBGesz8yBX'
+              },
             ],
           },
         ],


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

---

The previous link to the `#aqua` channel in `/dev/tty` Discord server will only work for users that have already been invited to the server.

This invite link will still take people to the `#aqua` channel.
