### PR TITLE
fix: reflect changes in aquaproj/aqua for shell setup example

### DIFF
--- a/docs/reference/config/shell-completion.md
+++ b/docs/reference/config/shell-completion.md
@@ -15,7 +15,7 @@ aqua supports the shell completion.
 
 ```sh
 if command -v aqua &> /dev/null; then
-    source <(aqua completion bash)
+    eval "$(aqua completion bash)"
 fi
 ```
 

--- a/docs/reference/usage.md
+++ b/docs/reference/usage.md
@@ -583,19 +583,19 @@ DESCRIPTION:
 
    e.g.
 
-   .bash_profile
+   # .bashrc
 
    if command -v aqua &> /dev/null; then
-     source <(aqua completion bash)
+     eval "$(aqua completion bash)"
    fi
 
-   .zprofile
+   # .zshrc
 
    if command -v aqua &> /dev/null; then
      source <(aqua completion zsh)
    fi
 
-   fish
+   # fish
 
    aqua completion fish > ~/.config/fish/completions/aqua.fish
 


### PR DESCRIPTION
See the commit message. This reflects the changes in https://github.com/aquaproj/aqua/pull/3297 to the online documentation.

References:

- https://github.com/aquaproj/aqua/issues/3294
- https://github.com/aquaproj/aqua/pull/3297

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
